### PR TITLE
Fix Missing Highlight For GUI

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -337,12 +337,26 @@
     -fx-background-radius: 0;
 }
 
-#tags {
+#skills {
     -fx-hgap: 7;
     -fx-vgap: 3;
 }
 
-#tags .label {
+#skills .label {
+    -fx-text-fill: white;
+    -fx-background-color: #3e7b91;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
+#requirements {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#requirements .label {
     -fx-text-fill: white;
     -fx-background-color: #3e7b91;
     -fx-padding: 1 3 1 3;

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -27,10 +27,10 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
+      <FlowPane fx:id="skills" hgap="5" vgap="5" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="role" styleClass="cell_small_label" text="\$role" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <FlowPane fx:id="skills" hgap="5" vgap="5" />
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
The GUI does not show highlights for skills and requirements.

Fix the styling issue to have better UI experience.

Update DarkTheme.css to include skills and requirements.

<img width="1275" alt="Screenshot 2024-10-23 at 5 16 36 AM" src="https://github.com/user-attachments/assets/849a4b74-75a3-46fa-974d-d42a6d5553fc">