### PR TITLE
Implement ListAllCommand to list all entities at once

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAllCommand.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_COMPANIES;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_JOBS;
+
+import seedu.address.model.Model;
+
+/**
+ * Lists all contacts, companies, and jobs in the address book to the user.
+ */
+public class ListAllCommand extends ListCommand {
+
+    public static final String ENTITY_WORD = "all";
+    public static final String MESSAGE_SUCCESS = "Listed all contacts, companies, and jobs";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        // Update each list individually to show all items
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredCompanyList(PREDICATE_SHOW_ALL_COMPANIES);
+        model.updateFilteredJobList(PREDICATE_SHOW_ALL_JOBS);
+
+        // Return a combined message indicating the operation's success
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ListAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAllCommand.java
@@ -2,8 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_COMPANIES;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_JOBS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.model.Model;
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -7,7 +7,7 @@ public abstract class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
     public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ": List the entity identified by argument 'contact', 'company' or 'job'\n"
-            + "Parameters: [contact/job/company]\nExample: " + COMMAND_WORD + " contact";
+            COMMAND_WORD + ": List the entity identified by argument 'contact', 'company' or 'job' or show all 'all'\n"
+            + "Parameters: [contact/job/company/all]\nExample: " + COMMAND_WORD + " contact";
 
 }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListAllCommand;
 import seedu.address.logic.commands.ListCompanyCommand;
 import seedu.address.logic.commands.ListContactCommand;
 import seedu.address.logic.commands.ListJobCommand;
@@ -37,6 +38,8 @@ public class ListCommandParser implements Parser<ListCommand> {
             return new ListJobCommand();
         case ListCompanyCommand.ENTITY_WORD:
             return new ListCompanyCommand();
+        case ListAllCommand.ENTITY_WORD:
+            return new ListAllCommand();
         default:
             throw new ParseException(ListCommand.MESSAGE_USAGE);
         }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -2,8 +2,8 @@ package seedu.address.logic.parser;
 
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListAllCommand;
+import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListCompanyCommand;
 import seedu.address.logic.commands.ListContactCommand;
 import seedu.address.logic.commands.ListJobCommand;

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,7 +1,6 @@
 package seedu.address.ui;
 
 import java.util.Comparator;
-import java.util.Optional;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;

--- a/src/test/java/seedu/address/logic/commands/ListAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListAllCommandTest.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class ListAllCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listAll_success() {
+        ListAllCommand listAllCommand = new ListAllCommand();
+
+        // Update expectedModel lists to show all entities
+        expectedModel.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        expectedModel.updateFilteredCompanyList(Model.PREDICATE_SHOW_ALL_COMPANIES);
+        expectedModel.updateFilteredJobList(Model.PREDICATE_SHOW_ALL_JOBS);
+
+        // Execute the command and get the result
+        CommandResult result = listAllCommand.execute(model);
+
+        // Verify success message
+        assertEquals(ListAllCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
+
+        // Verify the lists are updated to show all entities
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
+        assertEquals(expectedModel.getFilteredCompanyList(), model.getFilteredCompanyList());
+        assertEquals(expectedModel.getFilteredJobList(), model.getFilteredJobList());
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        ListAllCommand listAllCommand = new ListAllCommand();
+        assertThrows(NullPointerException.class, () -> listAllCommand.execute(null));
+    }
+}


### PR DESCRIPTION
Add a new `ListAllCommand` class to list all contacts, companies, and jobs in the address book simultaneously.
This command uses existing predicates to update the filtered lists for each entity, enhancing user experience by consolidating individual list commands.

- Define `ENTITY_WORD` as "all"
- Update all filtered lists using `PREDICATE_SHOW_ALL_PERSONS`, `PREDICATE_SHOW_ALL_COMPANIES`, and `PREDICATE_SHOW_ALL_JOBS`
- Return `CommandResult` with a combined success message
- Remove unused import optional from PersonCard.java 

This feature provides a convenient way for users to view all entities at once, improving accessibility and navigation.

- closes #143