### PR TITLE
Update Company and JobCompany's comparison methods to ignore case

### DIFF
--- a/src/main/java/seedu/address/model/company/Company.java
+++ b/src/main/java/seedu/address/model/company/Company.java
@@ -57,7 +57,7 @@ public class Company {
         }
 
         return otherCompany != null
-                && otherCompany.name.equals(this.name);
+                && otherCompany.name.fullName.equalsIgnoreCase(this.name.fullName); // done so as not to change Name's equals method
     }
 
     /**

--- a/src/main/java/seedu/address/model/company/Company.java
+++ b/src/main/java/seedu/address/model/company/Company.java
@@ -57,7 +57,8 @@ public class Company {
         }
 
         return otherCompany != null
-                && otherCompany.name.fullName.equalsIgnoreCase(this.name.fullName); // done so as not to change Name's equals method
+                // below line is done in this way as not to change Name's equals method
+                && otherCompany.name.fullName.equalsIgnoreCase(this.name.fullName);
     }
 
     /**

--- a/src/main/java/seedu/address/model/job/JobCompany.java
+++ b/src/main/java/seedu/address/model/job/JobCompany.java
@@ -32,7 +32,7 @@ public class JobCompany extends Name {
      * @return true if equal.
      */
     public boolean matchesCompanyName(Name name) {
-        return this.fullName.equals(name.fullName);
+        return this.fullName.equalsIgnoreCase(name.fullName);
     }
 
     @Override


### PR DESCRIPTION
closes #205 
The solution to this bug I implemented is quite rudimentary as I didn't want to change `Name`'s equals method. If we decide in the future that we want all names to be case-insensitive, we can either change `Name`'s equals method to be case-insensitive or create a new function in `Name` specifically for case-insensitive comparisons. However, that would require a lot of changes to files that previously used `Name`'s equals method for comparison.