### PR TITLE
Feedback invalid index via default parseIndex() exception instead of invalide format error

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -16,6 +16,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_DISPLAYED_INDEX = "The index provided is invalid";
     public static final String MESSAGE_MISSING_INDEX = "The index is missing";
     public static final String DELETE_COMMAND_USAGE = "Invalid delete command. Specify 'company', 'contact' or 'job'.";

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -33,7 +33,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         String entityType = splitArgs[0]; // either "contact, "job" or "company"
         String indexString = splitArgs[1];
 
-        Index index = ParserUtil.parseIndex(indexString);;
+        Index index = ParserUtil.parseIndex(indexString);
 
         switch (entityType) {
         case DeleteContactCommand.ENTITY_WORD:

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.DELETE_COMMAND_USAGE;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 
 import seedu.address.commons.core.index.Index;
@@ -34,13 +33,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         String entityType = splitArgs[0]; // either "contact, "job" or "company"
         String indexString = splitArgs[1];
 
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(indexString);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
-        }
+        Index index = ParserUtil.parseIndex(indexString);;
+
         switch (entityType) {
         case DeleteContactCommand.ENTITY_WORD:
             return new DeleteContactCommand(index);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -34,13 +34,13 @@ public class EditCommandParser implements Parser<EditCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROLE, PREFIX_SKILL);
 
-        Index index;
-
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+        boolean preambleIsEmpty = argMultimap.getPreamble().trim().isEmpty();
+        boolean preambleHasOneArgument = argMultimap.getPreamble().trim().split(" ").length == 1;
+        if (preambleIsEmpty || !preambleHasOneArgument) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
+
+        Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROLE);
 

--- a/src/main/java/seedu/address/logic/parser/MatchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MatchCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.MatchCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -28,15 +27,8 @@ public class MatchCommandParser implements Parser<MatchCommand> {
         String inputContactIndex = splitArgs[MatchCommand.CONTACT_INDEX_POS];
         String inputJobIndex = splitArgs[MatchCommand.JOB_INDEX_POS];
 
-        Index contactIndex;
-        Index jobIndex;
-        try {
-            contactIndex = ParserUtil.parseIndex(inputContactIndex);
-            jobIndex = ParserUtil.parseIndex(inputJobIndex);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(Messages.MESSAGE_INVALID_DISPLAYED_INDEX), pe);
-        }
+        Index contactIndex = ParserUtil.parseIndex(inputContactIndex);
+        Index jobIndex = ParserUtil.parseIndex(inputJobIndex);
 
         return new MatchCommand(contactIndex, jobIndex);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -41,7 +42,7 @@ public class ParserUtil {
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
      *
-     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
+     * @throws ParseException If the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.Messages;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.common.Address;
 import seedu.address.model.common.Name;
@@ -28,8 +29,6 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
      * {@code ArgumentMultimap}.
@@ -47,7 +46,7 @@ public class ParserUtil {
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(Messages.MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }

--- a/src/main/java/seedu/address/logic/parser/ScreenCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ScreenCommandParser.java
@@ -26,14 +26,8 @@ public class ScreenCommandParser implements Parser<ScreenCommand> {
         }
         String entityType = splitArgs[0];
         String indexString = splitArgs[1];
-        Index index;
+        Index index = ParserUtil.parseIndex(indexString);
 
-        try {
-            index = ParserUtil.parseIndex(indexString);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScreenCommand.MESSAGE_USAGE), pe);
-        }
         switch (entityType) {
         case ScreenJobCommand.ENTITY_WORD:
             return new ScreenJobCommand(index);

--- a/src/main/java/seedu/address/logic/parser/UnmatchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmatchCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.UnmatchCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -31,15 +30,8 @@ public class UnmatchCommandParser implements Parser<UnmatchCommand> {
         String inputContactIndex = splitArgs[UnmatchCommand.CONTACT_INDEX_POS];
         String inputJobIndex = splitArgs[UnmatchCommand.JOB_INDEX_POS];
 
-        Index contactIndex;
-        Index jobIndex;
-        try {
-            contactIndex = ParserUtil.parseIndex(inputContactIndex);
-            jobIndex = ParserUtil.parseIndex(inputJobIndex);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(Messages.MESSAGE_INVALID_DISPLAYED_INDEX), pe);
-        }
+        Index contactIndex = ParserUtil.parseIndex(inputContactIndex);
+        Index jobIndex = ParserUtil.parseIndex(inputJobIndex);
 
         return new UnmatchCommand(contactIndex, jobIndex);
     }

--- a/src/main/java/seedu/address/logic/parser/ViewCompanyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCompanyCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 
@@ -36,14 +35,7 @@ public class ViewCompanyCommandParser implements Parser<ViewCompanyCommand> {
 
         String indexString = splitArgs[1];
 
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(indexString);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                            ViewCompanyCommand.MESSAGE_USAGE), pe);
-        }
+        Index index = ParserUtil.parseIndex(indexString);
 
         return new ViewCompanyCommand(index);
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -38,14 +38,12 @@ public class DeleteCommandParserTest {
         assertParseFailure(parser, "contact", String.format(MESSAGE_MISSING_INDEX,
                 DeleteContactCommand.MESSAGE_USAGE));
 
-        assertParseFailure(parser, "contact a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteContactCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "contact a", MESSAGE_INVALID_INDEX);
     }
 
     @Test
     public void parse_invalidArgsCompany_throwsParseException() {
         assertParseFailure(parser, "company", MESSAGE_MISSING_INDEX); // No index provided
-        assertParseFailure(parser, "company a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteCompanyCommand.MESSAGE_USAGE)); // Non-numeric index
+        assertParseFailure(parser, "company a", MESSAGE_INVALID_INDEX); // Non-numeric index
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
@@ -69,10 +70,10 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_INDEX);
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_INDEX);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);

--- a/src/test/java/seedu/address/logic/parser/MatchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MatchCommandParserTest.java
@@ -1,13 +1,13 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.MatchCommand;
 
 public class MatchCommandParserTest {
@@ -36,7 +36,7 @@ public class MatchCommandParserTest {
 
     @Test
     public void parse_invalidIndex_failure() {
-        String expectedMessage = Messages.MESSAGE_INVALID_DISPLAYED_INDEX;
+        String expectedMessage = MESSAGE_INVALID_INDEX;
 
         // Arguments not number
         assertParseFailure(parser, "one one", expectedMessage);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 

--- a/src/test/java/seedu/address/logic/parser/ScreenCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ScreenCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -28,8 +29,7 @@ public class ScreenCommandParserTest {
 
     @Test
     public void parse_invalidIndex_throwsParseException() {
-        assertParseFailure(parser, "job abc",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScreenJobCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "job abc", MESSAGE_INVALID_INDEX);
     }
 
     @Test


### PR DESCRIPTION
- closes #139 
![image](https://github.com/user-attachments/assets/846558f5-5d90-4354-9478-8c483988093d)


Do you think invalid index such as "-1" or "one" should throw invalid format error or feedback "index is not non-zero integer"?
