### PR TITLE
[Pending #215] Enforce entity checks on most commands

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,6 +18,9 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_DISPLAYED_INDEX = "The index provided is invalid";
+    public static final String MESSAGE_INVALID_ENTITY = "Invalid entity '%1$s'. Valid entities are 'company', "
+            + "'contact', 'job', or 'all'";
+    public static final String MESSAGE_OPERATION_NOT_ALLOWED = "Command '%1$s' is not allowed on entity '%2$s'.";
     public static final String MESSAGE_MISSING_INDEX = "The index is missing";
     public static final String DELETE_COMMAND_USAGE = "Invalid delete command. Specify 'company', 'contact' or 'job'.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddCompanyCommand;
 import seedu.address.logic.commands.AddContactCommand;
@@ -21,6 +22,8 @@ public class AddCommandParser implements Parser<AddCommand<?>> {
         String entity = args.trim().split(" ")[0];
         String addArgs = args.replace(" " + entity, "");
 
+        ParserUtil.requireValidEntity(entity);
+
         switch (entity) {
         case AddContactCommand.ENTITY_WORD:
             return new AddContactCommandParser().parse(addArgs);
@@ -29,7 +32,9 @@ public class AddCommandParser implements Parser<AddCommand<?>> {
         case AddCompanyCommand.ENTITY_WORD:
             return new AddCompanyCommandParser().parse(addArgs);
         default:
-            throw new ParseException(AddCommand.MESSAGE_USAGE);
+            String exceptionMessage = String.format(Messages.MESSAGE_OPERATION_NOT_ALLOWED,
+                    AddCommand.COMMAND_WORD, entity);
+            throw new ParseException(exceptionMessage);
         }
 
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,8 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.DELETE_COMMAND_USAGE;
-
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteCompanyCommand;
 import seedu.address.logic.commands.DeleteContactCommand;
@@ -27,6 +26,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand<?>> {
         String entityType = splitArgs[0]; // either "contact, "job" or "company"
         String indexString = splitArgs[1];
 
+        ParserUtil.requireValidEntity(entityType);
         Index index = ParserUtil.parseIndex(indexString);
 
         switch (entityType) {
@@ -37,7 +37,9 @@ public class DeleteCommandParser implements Parser<DeleteCommand<?>> {
         case DeleteCompanyCommand.ENTITY_WORD:
             return new DeleteCompanyCommand(index);
         default:
-            throw new ParseException(DELETE_COMMAND_USAGE);
+            String exceptionMessage = String.format(Messages.MESSAGE_OPERATION_NOT_ALLOWED,
+                    DeleteCommand.COMMAND_WORD, entityType);
+            throw new ParseException(exceptionMessage);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ListAllCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListCompanyCommand;
@@ -33,6 +35,8 @@ public class ListCommandParser implements Parser<ListCommand> {
         String[] splitArgs = ParserUtil.parseRequiredNumberOfArguments(args, 1, ListCommand.MESSAGE_USAGE);
         String entityType = splitArgs[0];
 
+        ParserUtil.requireValidEntity(entityType);
+
         switch (entityType) {
         case ListContactCommand.ENTITY_WORD:
             return new ListContactCommand();
@@ -43,7 +47,9 @@ public class ListCommandParser implements Parser<ListCommand> {
         case ListAllCommand.ENTITY_WORD:
             return new ListAllCommand();
         default:
-            throw new ParseException(ListCommand.MESSAGE_USAGE);
+            String exceptionMessage = String.format(Messages.MESSAGE_OPERATION_NOT_ALLOWED,
+                    AddCommand.COMMAND_WORD, entityType);
+            throw new ParseException(exceptionMessage);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -43,6 +43,7 @@ public class ParserUtil {
      * Leading and trailing whitespaces will be trimmed.
      */
     public static void requireValidEntity(String entity) throws ParseException {
+        requireNonNull(entity);
         String trimmedEntity = entity.trim();
 
         // TODO: Not sure if this is magic string?

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -38,10 +38,28 @@ public class ParserUtil {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
+    /**
+     * Throws ParseException if {@code entity} provided is not a valid entity in the address book.
+     * Leading and trailing whitespaces will be trimmed.
+     */
+    public static void requireValidEntity(String entity) throws ParseException {
+        String trimmedEntity = entity.trim();
+
+        // TODO: Not sure if this is magic string?
+        switch (trimmedEntity) {
+        case "contact", "company", "job", "all":
+            break;
+        default:
+            String exceptionMessage = String.format(Messages.MESSAGE_INVALID_ENTITY, trimmedEntity);
+            throw new ParseException(exceptionMessage);
+        }
+    }
+
+
 
     /**
-     * Parses {@code input} into a String array of arguments and returns it. Leading and trailing whitespaces will be
-     * trimmed. Arguments are split by any number of whitespace.
+     * Parses a String input {@code args} into a String array of arguments and returns it. Leading and trailing
+     * whitespaces will be trimmed. Arguments are split by any number of whitespace.
      *
      * @param args A string containing arguments separated by whitespace.
      * @param requiredNumberOfArguments The required number of arguments in input.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -78,7 +77,7 @@ public class ParserUtil {
         String[] splitArguments = trimmedArgs.trim().split("\\s+");
 
         if (trimmedArgs.isEmpty() || splitArguments.length != requiredNumberOfArguments) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, usageMessage));
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, usageMessage));
         }
 
         return splitArguments;

--- a/src/main/java/seedu/address/logic/parser/ScreenCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ScreenCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ScreenCommand;
 import seedu.address.logic.commands.ScreenJobCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -20,13 +22,17 @@ public class ScreenCommandParser implements Parser<ScreenCommand> {
 
         String entityType = splitArgs[0];
         String indexString = splitArgs[1];
+
+        ParserUtil.requireValidEntity(entityType);
         Index index = ParserUtil.parseIndex(indexString);
 
         switch (entityType) {
         case ScreenJobCommand.ENTITY_WORD:
             return new ScreenJobCommand(index);
         default:
-            throw new ParseException(ScreenCommand.MESSAGE_USAGE);
+            String exceptionMessage = String.format(Messages.MESSAGE_OPERATION_NOT_ALLOWED,
+                    AddCommand.COMMAND_WORD, entityType);
+            throw new ParseException(exceptionMessage);
         }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -235,4 +235,9 @@ public class ParserUtilTest {
         assertThrows(ParseException.class, ()
                 ->ParserUtil.requireValidEntity("someInvalidEntity"));
     }
+
+    @Test
+    public void requireValidEntity_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.requireValidEntity(null));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX;
@@ -219,5 +220,19 @@ public class ParserUtilTest {
         String dateWithWhitespace = WHITESPACE + VALID_BILLING_DATE + WHITESPACE;
         BillingDate expectedDate = new BillingDate(VALID_BILLING_DATE);
         assertEquals(expectedDate, ParserUtil.parseBillingDate(dateWithWhitespace));
+    }
+
+    @Test
+    public void requireValidEntity_validEntity_noExceptionsThrown() throws Exception {
+        assertDoesNotThrow(() ->ParserUtil.requireValidEntity("contact"));
+        assertDoesNotThrow(() ->ParserUtil.requireValidEntity("job"));
+        assertDoesNotThrow(() ->ParserUtil.requireValidEntity("company"));
+        assertDoesNotThrow(() ->ParserUtil.requireValidEntity("all"));
+    }
+
+    @Test
+    public void requireValidEntity_invalidEntity_throwParseException() throws Exception {
+        assertThrows(ParseException.class, ()
+                ->ParserUtil.requireValidEntity("someInvalidEntity"));
     }
 }


### PR DESCRIPTION
- close #150
- close #137
- close #169
- close #156
- Check if operation allowed
  - <img src="https://github.com/user-attachments/assets/37101896-79a4-4823-a1f4-10169d09ea89" width="400" /> 
- Check if entity is valid
  - <img src="https://github.com/user-attachments/assets/1d2ba9b1-d87b-40f6-a437-b11b32291851" width="400" /> 
- Note
  - Not implemented in `Edit` & `Find` as they currently do not check entity, which is inconsistent with the command structure we are using. We should modify them, alternatively we could just disable them. 
  - I have not implement this in `ViewCompanyCommand` because it currently does not check entity?
  - `Match` & `Unmatch` do not take in entity so it is not needed