### PR TITLE
Enhance screen command to screen all candidates with case insensitive matching

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ScreenCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ScreenCommand.java
@@ -10,6 +10,7 @@ public abstract class ScreenCommand extends Command {
 
     public static final String COMMAND_WORD = "screen";
     public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ":  Screen the entity identified by argument 'job' "
-                    + "Parameters: [job] <INDEX>\nExample: " + COMMAND_WORD + " job 1";
+            COMMAND_WORD + ": Filters and displays entities matching the specified criteria. "
+                    + "\n\nParameters:\n- job <INDEX>: Screens and lists contacts that fit the specified job.\n"
+                    + "\nExample:\n" + COMMAND_WORD + " job 1";
 }

--- a/src/main/java/seedu/address/logic/commands/ScreenJobCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ScreenJobCommand.java
@@ -30,6 +30,7 @@ public class ScreenJobCommand extends ScreenCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Job> jobList = model.getFilteredJobList();
+        List<Person> fullPersonList = model.getFullPersonList();
 
         // Convert jobIndex to zero-based and check if it's valid
         if (targetIndex.getZeroBased() >= jobList.size()) {
@@ -42,7 +43,7 @@ public class ScreenJobCommand extends ScreenCommand {
                 .and(person -> !person.isMatchPresent());
 
         // Filter persons by checking if their role is present in the job requirements (case-insensitive)
-        List<Person> matchingPersons = model.getFilteredPersonList().stream()
+        List<Person> matchingPersons = fullPersonList.stream()
                 .filter(filterCriteria)
                 .collect(Collectors.toList());
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -161,4 +161,10 @@ public interface Model {
      * that are linked to the specified company.
      */
     void showLinkedJobsAndPersonsByCompany(Company company);
+
+    /** Returns an unmodifiable view of the full person list */
+    ObservableList<Person> getFullPersonList();
+
+    /** Returns an unmodifiable view of the full job list */
+    ObservableList<Job> getFullJobList();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -286,4 +286,28 @@ public class ModelManager implements Model {
         updateFilteredCompanyList(company -> company.equals(targetCompany));
     }
 
+    /**
+     * Returns an unmodifiable view of the full person list stored in the address book.
+     * This list includes all persons, regardless of any current filters applied
+     * to the filtered person list.
+     *
+     * @return An unmodifiable {@code ObservableList} of all persons in the address book.
+     */
+    @Override
+    public ObservableList<Person> getFullPersonList() {
+        return addressBook.getPersonList();
+    }
+
+    /**
+     * Returns an unmodifiable view of the full job list stored in the address book.
+     * This list includes all jobs, regardless of any current filters applied
+     * to the filtered job list.
+     *
+     * @return An unmodifiable {@code ObservableList} of all jobs in the address book.
+     */
+    @Override
+    public ObservableList<Job> getFullJobList() {
+        return addressBook.getJobList();
+    }
+
 }

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -150,4 +150,14 @@ public class ModelStub implements Model {
     public void showLinkedJobsAndPersonsByCompany(Company company) {
         throw new AssertionError("This method should not be called.");
     }
+
+    @Override
+    public ObservableList<Person> getFullPersonList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Job> getFullJobList() {
+        throw new AssertionError("This method should not be called.");
+    }
 }


### PR DESCRIPTION
case-insensitive matching

- Update ScreenJobCommand to operate on the entire list of contacts, ignoring any current filters, to ensure all candidates are screened.
- Add new methods `getFullPersonList` and `getFullJobList` to Model interface and implement them in ModelManager to retrieve
 unfiltered lists of persons and jobs, allowing comprehensive screening.
- Modify `roleMatchesJobPredicate` to support case-insensitive partial matching by converting both job names and person roles to lowercase, allowing flexible matching.
- Refine usage message for `screen job` command to clarify functionality and improve readability, making
parameters and examples more accessible.

- fixes #207 
- fixes #224 
- fixes #138

<img width="1275" alt="Screenshot 2024-11-05 at 3 33 19 AM" src="https://github.com/user-attachments/assets/897f8c53-9655-4a05-9159-6f45d0556abd">