### PR TITLE
Add labels for Contact, Job, and Company in MainWindow UI

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -364,3 +364,15 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+.label-contacts {
+    -fx-text-fill: #3498db;
+}
+
+.label-jobs {
+    -fx-text-fill: #2ecc71;
+}
+
+.label-companies {
+    -fx-text-fill: #e74c3c;
+}

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -3,6 +3,7 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
@@ -50,9 +51,23 @@
           <padding>
             <Insets bottom="10" left="10" right="10" top="10" />
           </padding>
-          <StackPane fx:id="personListPanelPlaceholder" HBox.hgrow="ALWAYS" />
-               <StackPane fx:id="jobListPanelPlaceholder" HBox.hgrow="ALWAYS" />
-               <StackPane fx:id="companyListPanelPlaceholder" HBox.hgrow="ALWAYS" />
+          <!-- Contact Panel with Label -->
+          <VBox spacing="5" HBox.hgrow="ALWAYS">
+            <Label text="Contacts" styleClass="label-contacts"/>
+            <StackPane fx:id="personListPanelPlaceholder" HBox.hgrow="ALWAYS" />
+          </VBox>
+
+          <!-- Job Panel with Label -->
+          <VBox spacing="5" HBox.hgrow="ALWAYS">
+            <Label text="Jobs" styleClass="label-jobs"/>
+            <StackPane fx:id="jobListPanelPlaceholder" HBox.hgrow="ALWAYS" />
+          </VBox>
+
+          <!-- Company Panel with Label -->
+          <VBox spacing="5" HBox.hgrow="ALWAYS">
+            <Label text="Companies" styleClass="label-companies"/>
+            <StackPane fx:id="companyListPanelPlaceholder" HBox.hgrow="ALWAYS" />
+          </VBox>
         </HBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />


### PR DESCRIPTION
- Updated `MainWindow.fxml` to add "Contact," "Job," and "Company" labels above their respective panels.
- Applied custom text colors for each label in the CSS file for better visual distinction:
    - Contacts label set to light blue (#3498db)
    - Jobs label set to green (#2ecc71)
    - Companies label set to red (#e74c3c)
- This update enhances the UI, making it easier for users to identify and navigate different sections in Talent Connect.

Resolves issue #236

Before
<img width="1275" alt="Screenshot 2024-11-05 at 11 50 53 PM" src="https://github.com/user-attachments/assets/6547feb3-b355-4d41-a9a2-3ebd00c4568c">


After
<img width="1275" alt="Screenshot 2024-11-05 at 11 49 53 PM" src="https://github.com/user-attachments/assets/65efc578-4f9c-4a7e-b70e-82517ae123dc">
