### PR TITLE
Add StatsCommand to AddressBookParser for command parsing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/StatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatsCommand.java
@@ -13,20 +13,20 @@ public class StatsCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays total counts for contacts, jobs, "
             + "companies, and match status.\n"
             + "Example: " + COMMAND_WORD;
-
+    public static final String MESSAGE_SUCCESS = "Total Contacts: %d\nTotal Jobs: %d\nTotal Companies: %d\n"
+            + "Matched Contacts: %d\nUnmatched Contacts: %d";
     @Override
     public CommandResult execute(Model model) {
         int totalContacts = model.getFilteredPersonList().size();
         int totalJobs = model.getFilteredJobList().size();
         int totalCompanies = model.getFilteredCompanyList().size();
 
-        long matchedContacts = model.getFilteredPersonList().stream()
+        int matchedContacts = (int) model.getFilteredPersonList().stream()
                 .filter(Person::isMatchPresent)
                 .count();
-        long unmatchedContacts = totalContacts - matchedContacts;
+        int unmatchedContacts = totalContacts - matchedContacts;
 
-        String resultMessage = String.format("Total Contacts: %d\nTotal Jobs: %d\nTotal Companies: "
-                        + "%d\nMatched Contacts: %d\nUnmatched Contacts: %d",
+        String resultMessage = String.format(MESSAGE_SUCCESS,
                 totalContacts, totalJobs, totalCompanies, matchedContacts, unmatchedContacts);
 
         return new CommandResult(resultMessage);

--- a/src/main/java/seedu/address/logic/commands/StatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatsCommand.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Displays statistics including total counts for contacts, jobs, and companies,
+ * as well as matched and unmatched contacts.
+ */
+public class StatsCommand extends Command {
+
+    public static final String COMMAND_WORD = "stats";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays total counts for contacts, jobs, "
+            + "companies, and match status.\n"
+            + "Example: " + COMMAND_WORD;
+
+    @Override
+    public CommandResult execute(Model model) {
+        int totalContacts = model.getFilteredPersonList().size();
+        int totalJobs = model.getFilteredJobList().size();
+        int totalCompanies = model.getFilteredCompanyList().size();
+
+        long matchedContacts = model.getFilteredPersonList().stream()
+                .filter(Person::isMatchPresent)
+                .count();
+        long unmatchedContacts = totalContacts - matchedContacts;
+
+        String resultMessage = String.format("Total Contacts: %d\nTotal Jobs: %d\nTotal Companies: "
+                        + "%d\nMatched Contacts: %d\nUnmatched Contacts: %d",
+                totalContacts, totalJobs, totalCompanies, matchedContacts, unmatchedContacts);
+
+        return new CommandResult(resultMessage);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return (other instanceof StatsCommand);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MatchCommand;
 import seedu.address.logic.commands.ScreenCommand;
+import seedu.address.logic.commands.StatsCommand;
 import seedu.address.logic.commands.UnmatchCommand;
 import seedu.address.logic.commands.ViewCompanyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -93,6 +94,8 @@ public class AddressBookParser {
         case UnmatchCommand.COMMAND_WORD:
             return new UnmatchCommandParser().parse(arguments);
 
+        case StatsCommand.COMMAND_WORD:
+            return new StatsCommand();
         default:
             logger.finer("This user input caused a ParseException: " + userInput);
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);


### PR DESCRIPTION
- Import StatsCommand in AddressBookParser to handle the "stats" command.
- Add a new case in the parser’s switch statement to recognize and execute StatsCommand.
- Ensure that users can access the statistics functionality through the "stats" command in the UI.

Resolves issue #238

<img width="1783" alt="Screenshot 2024-11-06 at 12 17 45 AM" src="https://github.com/user-attachments/assets/18ff7286-baf9-4fa5-9bb1-1160eae0cdbe">
