### PR TITLE
Enforce checking of arguments count for Command with fixed number of arguments

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.DELETE_COMMAND_USAGE;
-import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -13,27 +13,22 @@ import seedu.address.logic.parser.exceptions.ParseException;
 /**
  * Parses input arguments and creates a new subclass of DeleteCommand object
  */
-public class DeleteCommandParser implements Parser<DeleteCommand> {
+public class DeleteCommandParser implements Parser<DeleteCommand<?>> {
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteContactCommand
      * and returns a DeleteCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
-    public DeleteCommand parse(String args) throws ParseException {
+    public DeleteCommand<?> parse(String args) throws ParseException {
 
 
-        String[] splitArgs = args.trim().split("\\s+");
-
-        if (args.length() < 1) {
-            throw new ParseException(DELETE_COMMAND_USAGE);
-        } else if (splitArgs.length < 2) {
-            throw new ParseException(MESSAGE_MISSING_INDEX);
-        }
+        String[] splitArgs = ParserUtil.parseRequiredNumberOfArguments(args, 2, DeleteCommand.MESSAGE_USAGE);
 
         String entityType = splitArgs[0]; // either "contact, "job" or "company"
         String indexString = splitArgs[1];
 
-        Index index = ParserUtil.parseIndex(indexString);;
+        Index index = ParserUtil.parseIndex(indexString);
 
         switch (entityType) {
         case DeleteContactCommand.ENTITY_WORD:

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -29,9 +29,11 @@ public class ListCommandParser implements Parser<ListCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ListCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
 
-        switch (trimmedArgs) {
+        String[] splitArgs = ParserUtil.parseRequiredNumberOfArguments(args, 1, ListCommand.MESSAGE_USAGE);
+        String entityType = splitArgs[0];
+
+        switch (entityType) {
         case ListContactCommand.ENTITY_WORD:
             return new ListContactCommand();
         case ListJobCommand.ENTITY_WORD:

--- a/src/main/java/seedu/address/logic/parser/MatchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MatchCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MatchCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,12 +15,7 @@ public class MatchCommandParser implements Parser<MatchCommand> {
      */
     public MatchCommand parse(String args) throws ParseException {
 
-
-        String[] splitArgs = args.trim().split("\\s+");
-
-        if (splitArgs.length != 2) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MatchCommand.MESSAGE_USAGE));
-        }
+        String[] splitArgs = ParserUtil.parseRequiredNumberOfArguments(args, 2, MatchCommand.MESSAGE_USAGE);
 
         String inputContactIndex = splitArgs[MatchCommand.CONTACT_INDEX_POS];
         String inputJobIndex = splitArgs[MatchCommand.JOB_INDEX_POS];

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -38,6 +38,33 @@ public class ParserUtil {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
+
+    /**
+     * Parses {@code input} into a String array of arguments and returns it. Leading and trailing whitespaces will be
+     * trimmed. Arguments are split by any number of whitespace.
+     *
+     * @param args A string containing arguments separated by whitespace.
+     * @param requiredNumberOfArguments The required number of arguments in input.
+     * @param usageMessage The usage message of a command to format error message.
+     * @return A String array of arguments.
+     * @throws ParseException If the input provided does not have the required number of arguments.
+     */
+    public static String[] parseRequiredNumberOfArguments(String args, int requiredNumberOfArguments,
+            String usageMessage) throws ParseException {
+        requireNonNull(args);
+        requireNonNull(usageMessage);
+
+        String trimmedArgs = args.trim();
+
+        String[] splitArguments = trimmedArgs.trim().split("\\s+");
+
+        if (trimmedArgs.isEmpty() || splitArguments.length != requiredNumberOfArguments) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, usageMessage));
+        }
+
+        return splitArguments;
+    }
+
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -59,7 +58,7 @@ public class ParserUtil {
         String[] splitArguments = trimmedArgs.trim().split("\\s+");
 
         if (trimmedArgs.isEmpty() || splitArguments.length != requiredNumberOfArguments) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, usageMessage));
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, usageMessage));
         }
 
         return splitArguments;

--- a/src/main/java/seedu/address/logic/parser/ScreenCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ScreenCommandParser.java
@@ -1,8 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ScreenCommand;
 import seedu.address.logic.commands.ScreenJobCommand;
@@ -18,12 +15,9 @@ public class ScreenCommandParser implements Parser<ScreenCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ScreenCommand parse(String args) throws ParseException {
-        String[] splitArgs = args.trim().split("\\s+");
-        if (splitArgs.length == 1 && splitArgs[0].equals(ScreenJobCommand.ENTITY_WORD)) {
-            throw new ParseException(MESSAGE_MISSING_INDEX);
-        } else if (splitArgs.length == 1 || splitArgs.length >= 3) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScreenCommand.MESSAGE_USAGE));
-        }
+
+        String[] splitArgs = ParserUtil.parseRequiredNumberOfArguments(args, 2, ScreenCommand.MESSAGE_USAGE);
+
         String entityType = splitArgs[0];
         String indexString = splitArgs[1];
         Index index = ParserUtil.parseIndex(indexString);

--- a/src/main/java/seedu/address/logic/parser/UnmatchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmatchCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UnmatchCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -20,12 +18,7 @@ public class UnmatchCommandParser implements Parser<UnmatchCommand> {
      */
     public UnmatchCommand parse(String args) throws ParseException {
 
-
-        String[] splitArgs = args.trim().split("\\s+");
-
-        if (splitArgs.length != 2) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmatchCommand.MESSAGE_USAGE));
-        }
+        String[] splitArgs = ParserUtil.parseRequiredNumberOfArguments(args, 2, UnmatchCommand.MESSAGE_USAGE);
 
         String inputContactIndex = splitArgs[UnmatchCommand.CONTACT_INDEX_POS];
         String inputJobIndex = splitArgs[UnmatchCommand.JOB_INDEX_POS];

--- a/src/main/java/seedu/address/logic/parser/ViewCompanyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCompanyCommandParser.java
@@ -1,8 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
-import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewCompanyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -20,21 +17,9 @@ public class ViewCompanyCommandParser implements Parser<ViewCompanyCommand> {
      */
     public ViewCompanyCommand parse(String args) throws ParseException {
 
-        String[] splitArgs = args.trim().split("\\s+");
-
-        if (args.isEmpty()) {
-            throw new ParseException(ViewCompanyCommand.MESSAGE_USAGE);
-        } else if (splitArgs.length < 2) {
-            throw new ParseException(MESSAGE_MISSING_INDEX);
-        }
-
-        // TODO: Implement an entity for view command
-        if (!splitArgs[0].equals("company")) {
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
-        }
+        String[] splitArgs = ParserUtil.parseRequiredNumberOfArguments(args, 2, ViewCompanyCommand.MESSAGE_USAGE);
 
         String indexString = splitArgs[1];
-
         Index index = ParserUtil.parseIndex(indexString);
 
         return new ViewCompanyCommand(index);

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX;
-import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_COMPANY;
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteCompanyCommand;
 import seedu.address.logic.commands.DeleteContactCommand;
 
@@ -34,16 +35,14 @@ public class DeleteCommandParserTest {
     }
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "contact", String.format(MESSAGE_MISSING_INDEX,
-                DeleteContactCommand.MESSAGE_USAGE));
-
+    public void parse_invalidIndex_throwsParseException() {
         assertParseFailure(parser, "contact a", MESSAGE_INVALID_INDEX);
     }
 
     @Test
     public void parse_invalidArgsCompany_throwsParseException() {
-        assertParseFailure(parser, "company", MESSAGE_MISSING_INDEX); // No index provided
+        assertParseFailure(parser, "company",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE)); // No index provided
         assertParseFailure(parser, "company a", MESSAGE_INVALID_INDEX); // Non-numeric index
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -220,4 +220,39 @@ public class ParserUtilTest {
         BillingDate expectedDate = new BillingDate(VALID_BILLING_DATE);
         assertEquals(expectedDate, ParserUtil.parseBillingDate(dateWithWhitespace));
     }
+
+    @Test
+    public void parseRequiredNumberOfArguments_validInput_returnSplitArgs() throws Exception {
+        String inputString = WHITESPACE + "1" + WHITESPACE + "2" + WHITESPACE;
+        int numberOfArguments = 2;
+        String usageMessage = "sample usage message";
+
+        String[] expectedOutput = {"1", "2"};
+        String[] actualOutput = ParserUtil.parseRequiredNumberOfArguments(inputString, numberOfArguments, usageMessage);
+
+        assertEquals(numberOfArguments, expectedOutput.length);
+        assertEquals(expectedOutput.length, actualOutput.length);
+        for (int i = 0; i < numberOfArguments; i++) {
+            assertEquals(expectedOutput[i], actualOutput[i]);
+        }
+    }
+
+    @Test
+    public void parseRequiredNumberOfArguments_incorrectNumberOfArguments_throwException() throws Exception {
+        String inputString = WHITESPACE + "1" + WHITESPACE + "2" + WHITESPACE;
+        int numberOfArguments = 3;
+        String usageMessage = "sample usage message";
+
+        assertThrows(ParseException.class, ()
+                -> ParserUtil.parseRequiredNumberOfArguments(inputString, numberOfArguments, usageMessage));
+    }
+
+    @Test
+    public void parseRequiredNumberOfArguments_emptyInput_throwException() throws Exception {
+        int numberOfArguments = 0;
+        String usageMessage = "sample usage message";
+
+        assertThrows(ParseException.class, ()
+                -> ParserUtil.parseRequiredNumberOfArguments(WHITESPACE, numberOfArguments, usageMessage));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/ScreenCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ScreenCommandParserTest.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX;
-import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -22,9 +21,16 @@ public class ScreenCommandParserTest {
     }
 
     @Test
-    public void parse_missingIndex_throwsParseException() {
-        assertParseFailure(parser, "job ",
-                String.format(MESSAGE_MISSING_INDEX));
+    public void parse_incorrectArgumentCount_throwsParseException() {
+
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScreenJobCommand.MESSAGE_USAGE);
+
+        // Too few arguments
+        assertParseFailure(parser, "job ", expectedMessage);
+        assertParseFailure(parser, "1", expectedMessage);
+
+        // Too many arguments
+        assertParseFailure(parser, "job 1 something", expectedMessage);
     }
 
     @Test


### PR DESCRIPTION
- Throw when there are too many/few arguments
![image](https://github.com/user-attachments/assets/a7937c64-2c60-4899-897b-3e56ef97083b)
- Take precedent of other errors, such as invalid index
![image](https://github.com/user-attachments/assets/d76530a9-091b-43a2-babc-470a14b9f143)

- ViewCompanyCommand
  - I removed missing index error, it does not make sense to use this error unless your validate the entity as well
  - e.g. `view 1` will still return missing index error, even though it is the entity that is missing. 
  - Missing/additional arguments (for command with fixed number of argument) will now all return invalid format error
- ScreenCommand
  - Same as above
  - Related to https://github.com/AY2425S1-CS2103-F13-4/tp/issues/150