### PR TITLE
Resolve issue #154

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -71,6 +71,7 @@ public class EditCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> fullPersonList = model.getFullPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_DISPLAYED_INDEX);
@@ -79,7 +80,14 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+        // A person's uniqueness is based on their phone and email. If the edit command results in sharing those
+        // identifiers with 2 others, it means the uniqueness invariant was violated and hence there are duplicates.
+        if (countDuplicatePerson(fullPersonList, editedPerson) == 2) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+        // This covers an edge case, when the edit command changes both the phone and email to fully match another
+        // existing person, which will circumvent the above check.
+        if (!personToEdit.isSamePerson(editedPerson) && countDuplicatePerson(fullPersonList, editedPerson) == 1) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
@@ -102,6 +110,21 @@ public class EditCommand extends Command {
         Set<Skill> updatedSkills = editPersonDescriptor.getSkills().orElse(personToEdit.getSkills());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedRole, updatedSkills);
+    }
+
+    /**
+     * Counts and returns the number of duplicate persons in the provided list based on the {@code isSamePerson} check
+     * against the specified person.
+     *
+     * @param personList The list of persons to check for duplicates.
+     * @param personToCompare The specified person to be compared against each person in {@code personList}.
+     */
+    private static long countDuplicatePerson(List<Person> personList, Person personToCompare) {
+        long count = personList.stream()
+                .filter(p -> p.isSamePerson(personToCompare))
+                .count();
+
+        return count;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -80,14 +80,16 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        // A person's uniqueness is based on their phone and email. If the edit command results in sharing those
-        // identifiers with 2 others, it means the uniqueness invariant was violated and hence there are duplicates.
-        if (countDuplicatePerson(fullPersonList, editedPerson) == 2) {
+        // Handles case where edit command changes one of the two fields which uniquely identifies a person, contact
+        // or email. The editedPerson is considered the same person as personToEdit and is counted as a duplicate.
+        // If there are 2 duplicates, it means that there is another existing contact with the same identifier.
+        // While there should not be a case where there are 3 or more duplicates, good to be defensive.
+        if (personToEdit.isSamePerson(editedPerson) && countDuplicatePerson(fullPersonList, editedPerson) >= 2) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
-        // This covers an edge case, when the edit command changes both the phone and email to fully match another
-        // existing person, which will circumvent the above check.
-        if (!personToEdit.isSamePerson(editedPerson) && countDuplicatePerson(fullPersonList, editedPerson) == 1) {
+        // Handles case where edit command changes both fields that uniquely identify a person. In this case, there
+        // should not be any duplicates at all.
+        if (!personToEdit.isSamePerson(editedPerson) && countDuplicatePerson(fullPersonList, editedPerson) >= 1) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 


### PR DESCRIPTION
Turns out there was indeed an elegant solution to the edit command issue.

To verify the correctness, let Ep refer to existing person in the list.

## Case: change either phone or email (Note: personToEdit is still considered same as editedPerson)
- If the changed field exists in Ep
  - personToEdit and Ep will return true for `isSamePerson(editedPerson)` 
    - Hence, `countDuplicates` = 2. Exception thrown
- If the changed field is unique
  - `countDuplicates` = 1, pass first check
  - `!personToEdit.isSamePerson(editedPerson)` = false, pass second check

## Case change both phone and email (Note: Changing a field to the original value is the same as not changing it, so it reduces to the above case)
- If the changed fields are unique
  - `countDuplicates` = 0, clear that it passes both
- If the changed fields match Ep
  - `countDuplicates` = 1, pass first check
  - `!personToEdit.isSamePerson(editedPerson)` = true and `countDuplicates` = 1. Exception thrown  
- If the changed fields match Ep1 and Ep2 
  - `countDuplicates` = 2. Exception thrown 

- Closes #154 