### PR TITLE
Fix padding issue at the bottom of panels in Talent Connect

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -51,22 +51,28 @@
             <Insets bottom="10" left="10" right="10" top="10" />
           </padding>
           <!-- Contact Panel with Label -->
-          <VBox spacing="5" HBox.hgrow="ALWAYS">
-            <Label text="Contacts" styleClass="label-contacts"/>
-            <StackPane fx:id="personListPanelPlaceholder" HBox.hgrow="ALWAYS" />
-          </VBox>
+          <StackPane HBox.hgrow="ALWAYS">
+            <VBox>
+              <Label text="Contacts" styleClass="label-contacts"/>
+              <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+            </VBox>
+          </StackPane>
 
           <!-- Job Panel with Label -->
-          <VBox spacing="5" HBox.hgrow="ALWAYS">
-            <Label text="Jobs" styleClass="label-jobs"/>
-            <StackPane fx:id="jobListPanelPlaceholder" HBox.hgrow="ALWAYS" />
-          </VBox>
+          <StackPane HBox.hgrow="ALWAYS">
+            <VBox>
+              <Label text="Jobs" styleClass="label-jobs"/>
+              <StackPane fx:id="jobListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+            </VBox>
+          </StackPane>
 
           <!-- Company Panel with Label -->
-          <VBox spacing="5" HBox.hgrow="ALWAYS">
-            <Label text="Companies" styleClass="label-companies"/>
-            <StackPane fx:id="companyListPanelPlaceholder" HBox.hgrow="ALWAYS" />
-          </VBox>
+          <StackPane HBox.hgrow="ALWAYS">
+            <VBox>
+              <Label text="Companies" styleClass="label-companies"/>
+              <StackPane fx:id="companyListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+            </VBox>
+          </StackPane>
         </HBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />


### PR DESCRIPTION
- Resolve inconsistent padding at the bottom of the Contacts, Jobs, and Companies panels, especially when resizing the window.
- Adjust FXML structure to ensure consistent padding in StackPane and VBox elements.
- Apply explicit padding and alignment properties to prevent collapsing space on resize.
- Ensure a uniform layout for improved user experience , maintaining consistent space around each panel.

Before
<img width="2672" alt="Screenshot 2024-11-07 at 4 50 49 AM" src="https://github.com/user-attachments/assets/2a15b010-cc32-4d81-bc8e-11c0bd5bc3f1">

After
<img width="2445" alt="Screenshot 2024-11-07 at 4 51 50 AM" src="https://github.com/user-attachments/assets/dca1c15a-4ae6-4c24-bde0-5d9c04628e34">
