### PR TITLE
fix: Specify that our user only deal with English for work

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -274,6 +274,7 @@ _{Explain here how the data archiving feature will be implemented}_
 * prefer desktop apps over other types
 * prefers typing to mouse interactions
 * is reasonably comfortable using CLI apps
+* only deal with English for work
 
 **Value proposition**: manage contacts faster than a typical mouse/GUI driven app with functionality for quick matching of candidates to jobs
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -274,7 +274,7 @@ _{Explain here how the data archiving feature will be implemented}_
 * prefer desktop apps over other types
 * prefers typing to mouse interactions
 * is reasonably comfortable using CLI apps
-* only deal with English for work
+* only deals with English for work
 
 **Value proposition**: manage contacts faster than a typical mouse/GUI driven app with functionality for quick matching of candidates to jobs
 


### PR DESCRIPTION
- closes #351

Issue: Reported functional bug where non-English (non-alphanumeric) name cannot be added. 

Solution: Specify in DG that our target user only deal with English for work