### PR TITLE
fix: Incorrect success message for add and delete contact

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactCommand.java
@@ -31,7 +31,7 @@ public class AddContactCommand extends AddCommand<Person> {
             + PREFIX_ROLE + "copywriter";
 
     public static final String MESSAGE_SUCCESS = "Candidate added: Name: %1$s; "
-            + "Email: %2$s; Phone: %3$s; Applying for: %4$s.";
+            + "Phone: %2$s; Email: %3$s; Applying for: %4$s.";
 
     public static final String MESSAGE_DUPLICATE_CONTACT = "A candidate with this phone number "
             + "or email already exists.";

--- a/src/main/java/seedu/address/logic/commands/DeleteContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.person.Person;
 public class DeleteContactCommand extends DeleteCommand<Person> {
     public static final String ENTITY_WORD = "contact";
     public static final String MESSAGE_DELETE_CONTACT_SUCCESS = "Contact deleted: Name: %1$s; "
-            + "Email: %2$s; Phone: %3$s.";
+            + "Phone: %2$s; Email: %3$s.";
 
     public DeleteContactCommand(Index targetIndex) {
         super(targetIndex);


### PR DESCRIPTION
- Closes #274
- Closes #304 

Does this violate feature freeze?  
Ans: No, because it is a strictly incorrect behaviour instead of a could be better. 

I give +1.5 for tester B.

### After changes 

<img width="652" alt="Screenshot 2024-11-10 at 12 31 19 AM" src="https://github.com/user-attachments/assets/14bdb5e6-d735-4fe5-8ec3-845cfe3604dc">
<img width="683" alt="Screenshot 2024-11-10 at 12 31 30 AM" src="https://github.com/user-attachments/assets/b6f11baf-5b68-43e6-a405-addc1036bc32">
