### PR TITLE
fix: Wrong messages for skill, requirement

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactCommand.java
@@ -23,7 +23,7 @@ public class AddContactCommand extends AddCommand<Person> {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ROLE + "ROLE "
-            + "[" + PREFIX_SKILL + "SKILLS]... (Optional)\n"
+            + "[" + PREFIX_SKILL + "SKILL]... (Optional)\n"
             + "Example: " + FULL_COMMAND + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "

--- a/src/main/java/seedu/address/logic/commands/AddJobCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddJobCommand.java
@@ -27,7 +27,7 @@ public class AddJobCommand extends AddCommand<Job> {
             + PREFIX_COMPANY + "COMPANY "
             + PREFIX_SALARY + "MONTHLY_SALARY "
             + PREFIX_DESCRIPTION + "DESCRIPTION "
-            + "[" + PREFIX_REQUIREMENTS + "REQUIREMENTS]... (Optional)\n"
+            + "[" + PREFIX_REQUIREMENTS + "REQUIREMENT]... (Optional)\n"
             + "Example: " + FULL_COMMAND + " "
             + PREFIX_NAME + "Waiter "
             + PREFIX_COMPANY + "Starbucks "

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Requirement names should be alphanumeric";
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String tagName;


### PR DESCRIPTION
- closes #281 
- closes #278 
- closes #329 

Tester B already had 1.5, I will give him another 0.5 for this. Note that this running count doesn't include my big PR so at the end will tally. 

Does this violate feature freeze?
Ans: No, refer to https://github.com/nus-cs2103-AY2425S1/forum/issues/663 which I raised.  

Converting skills/requirements to skill/requirement is fine as in the forum. 
Then converting Salary in UG to Monthly_Salary is a UG change (can go other way round too).

Lastly, error message for requirement is fine, since Tag is an outdated term.  

Edit: As an aside, is it a code quality issue if everything in the Tag class is `Tag`, but just that the error message was reworded to `Requirement`.
