### PR TITLE
fix: Edit contact does not affect match

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -113,7 +113,12 @@ public class EditCommand extends Command {
         Role updatedRole = editPersonDescriptor.getRole().orElse(personToEdit.getRole());
         Set<Skill> updatedSkills = editPersonDescriptor.getSkills().orElse(personToEdit.getSkills());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedRole, updatedSkills);
+        if(personToEdit.getMatch().isPresent()) {
+            String match = personToEdit.getMatch().get();
+            return new Person(updatedName, updatedPhone, updatedEmail, updatedRole, updatedSkills, match);
+        } else {
+            return new Person(updatedName, updatedPhone, updatedEmail, updatedRole, updatedSkills);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -113,7 +113,7 @@ public class EditCommand extends Command {
         Role updatedRole = editPersonDescriptor.getRole().orElse(personToEdit.getRole());
         Set<Skill> updatedSkills = editPersonDescriptor.getSkills().orElse(personToEdit.getSkills());
 
-        if(personToEdit.getMatch().isPresent()) {
+        if (personToEdit.getMatch().isPresent()) {
             String match = personToEdit.getMatch().get();
             return new Person(updatedName, updatedPhone, updatedEmail, updatedRole, updatedSkills, match);
         } else {


### PR DESCRIPTION
- closes #357

This is strictly an incorrect behavior, edit a contact's email should not cause them to lose their job, therefore this is a functionality bug. 