### PR TITLE
Correct command format for some commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MatchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MatchCommand.java
@@ -28,7 +28,7 @@ public class MatchCommand extends Command {
 
     public static final String COMMAND_WORD = "match";
     public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ": Match a contact to a job\nParameters: <CONTACT_INDEX> <JOB_INDEX>\nExample: "
+            COMMAND_WORD + ": Match a contact to a job\nParameters: CONTACT_INDEX JOB_INDEX\nExample: "
                     + COMMAND_WORD + " 2 1";
     public static final String MESSAGE_MATCH_SUCCESS = "Matched Contact: %1$s with Job: %2$s";
     public static final String MESSAGE_HAS_OTHER_MATCHES = "Contact already has another job!";

--- a/src/main/java/seedu/address/logic/commands/ScreenCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ScreenCommand.java
@@ -11,6 +11,6 @@ public abstract class ScreenCommand extends Command {
     public static final String COMMAND_WORD = "screen";
     public static final String MESSAGE_USAGE =
             COMMAND_WORD + ": Filters and displays entities matching the specified criteria. "
-                    + "\n\nParameters:\n- job <INDEX>: Screens and lists contacts that fit the specified job.\n"
+                    + "\n\nParameters:\n- job INDEX: Screens and lists contacts that fit the specified job.\n"
                     + "\nExample:\n" + COMMAND_WORD + " job 1";
 }

--- a/src/main/java/seedu/address/logic/commands/UnmatchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmatchCommand.java
@@ -28,7 +28,7 @@ public class UnmatchCommand extends Command {
     public static final int JOB_INDEX_POS = 1;
     public static final String COMMAND_WORD = "unmatch";
     public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ": Unmatch a contact from a job\nParameters: <CONTACT_INDEX> <JOB_INDEX>\nExample: "
+            COMMAND_WORD + ": Unmatch a contact from a job\nParameters: CONTACT_INDEX JOB_INDEX\nExample: "
                     + COMMAND_WORD + " 2 1";
     public static final String MESSAGE_CONTACT_MATCHED_TO_OTHER_JOB = "The contact is matched to another job!";
 


### PR DESCRIPTION
- closes #349 

- UG specify that the format of some commands such as `screen job` has the format of `screen job INDEX`, and the app display a different and incorrect format. 
- Related issue [Ben's forum question](https://github.com/nus-cs2103-AY2425S1/forum/issues/663)
