### PR TITLE
344 pe dtester e stats bug dependent on view

### DIFF
--- a/src/main/java/seedu/address/logic/commands/StatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatsCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 
 /**
@@ -17,11 +19,14 @@ public class StatsCommand extends Command {
             + "Matched Contacts: %d\nUnmatched Contacts: %d";
     @Override
     public CommandResult execute(Model model) {
-        int totalContacts = model.getFilteredPersonList().size();
-        int totalJobs = model.getFilteredJobList().size();
-        int totalCompanies = model.getFilteredCompanyList().size();
 
-        int matchedContacts = (int) model.getFilteredPersonList().stream()
+        ReadOnlyAddressBook fullAddressBook = model.getAddressBook();
+
+        int totalContacts = fullAddressBook.getPersonList().size();
+        int totalJobs = fullAddressBook.getJobList().size();
+        int totalCompanies = fullAddressBook.getCompanyList().size();
+
+        int matchedContacts = (int) fullAddressBook.getPersonList().stream()
                 .filter(Person::isMatchPresent)
                 .count();
         int unmatchedContacts = totalContacts - matchedContacts;

--- a/src/main/java/seedu/address/logic/commands/StatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatsCommand.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;


### PR DESCRIPTION
- closes #344 

Return stats of the full address book instead of only the visible items. 

This is a functional bug, because its behavior differs from what is advertised in UG, which states that this command shows "total number of contacts, jobs, and companies in the address book".

