### PR TITLE
fix: Simplify screen job descriptin to make is clearer

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -237,8 +237,7 @@ Examples:
 
 ### Screening contacts by a job's name : `screen job`
 
-Screens the list of contacts in the address book with the name of the
-job specified.
+Screens the list of contacts in the address book with the job specified.
 
 Format: `screen job INDEX`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -235,7 +235,7 @@ Examples:
 * `list company` followed by `delete company 2` deletes the 2nd company in the address book.
 * If the company at index 1 has a job attributed to it, `delete company 1` will also delete the job.
 
-### Screening contacts by a job's name : `screen job`
+### Screening contacts by a job : `screen job`
 
 Screens the list of contacts in the address book with the job specified.
 


### PR DESCRIPTION
- closes #296 

The tester misunderstood that we are specifying the job with the name of the job. 

Small change, I think without it the document is still strictly correct. 