### PR TITLE
330 pe dtester c screen job does not work as specified in ug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -247,7 +247,7 @@ list of contacts to contacts with role matching the name.
 * Contacts that are already matched will not be shown. 
 * The index refers to the index number shown in the displayed job list.
 * The index **must be a positive integer** 1, 2, 3, …​
-* The filter is case-insensitive can be partial. e.g. Role `software engineer` will match to job name `Junior Java Software Engineer, Depart...`
+* The filter is case-insensitive and can be partial. e.g. Role `software engineer` will match to job name `Junior Java Software Engineer, Depart...`
 
 Examples:
 * If the job at index 1 has name `Software Engineer`, `screen job 1` will

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -249,7 +249,7 @@ list of contacts to contacts with role matching the name.
 * The index **must be a positive integer** 1, 2, 3, …​
 * The filter is case-insensitive can be partial. e.g. Role `software engineer` will match to job name `Junior Java Software Engineer, Depart...`
 
-  Examples:
+Examples:
 * If the job at index 1 has name `Software Engineer`, `screen job 1` will
 show a contact with role `Software Engineer`.
 * If the job at index 2 has name `Data Scientist`, `screen job 2` will 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -247,9 +247,9 @@ list of contacts to contacts with role matching the name.
 * Contacts that are already matched will not be shown. 
 * The index refers to the index number shown in the displayed job list.
 * The index **must be a positive integer** 1, 2, 3, …​
-* The filter is case-insensitive i.e. `Cleaner` will match `cleaner`.
+* The filter is case-insensitive can be partial. e.g. Role `software engineer` will match to job name `Junior Java Software Engineer, Depart...`
 
-Examples:
+  Examples:
 * If the job at index 1 has name `Software Engineer`, `screen job 1` will
 show a contact with role `Software Engineer`.
 * If the job at index 2 has name `Data Scientist`, `screen job 2` will 


### PR DESCRIPTION
- closes #330

Kindly help to vet my English. Particularly I think the sentence is kind of awkward and could be better rephrased. 

Original sentence:
* The contacts role to job name matching is case-insensitive can be partial. e.g. Role `software engineer` will match to job name `Junior Java Software Engineer, Depart...`