### PR TITLE
Add wrapText to UI elements

### DIFF
--- a/src/main/resources/view/JobListCard.fxml
+++ b/src/main/resources/view/JobListCard.fxml
@@ -25,7 +25,7 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true"/>
       </HBox>
       <FlowPane fx:id="requirements" vgap = "5" hgap = "5"/>
       <Label fx:id="company" styleClass="cell_small_label" text="\$company" />

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,7 +31,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="role" styleClass="cell_small_label" text="\$role" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <Label fx:id="match" styleClass="cell_small_label" text="\$match" />
+      <Label fx:id="match" styleClass="cell_small_label" text="\$match" wrapText="true" />
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
- Closes #373 
  - Within it, closes #324 
  - Within it, closes #321 

https://github.com/nus-cs2103-AY2425S1/forum/issues/629

Does this violate feature freeze? 
Ans: Probably not. Quote from Prof - "If you are asking if this can be fixed in v1.6, the answer is, 'only if there is no other way for the user to see the truncated part'".

For reasonable inputs, certain monitors are unable to see the jobMatchStatus or jobTitle. 

Company related stuff can be truncated too, HOWEVER, we can use view company to see the details, hence there are work arounds for it.

Was going to provide screenshots, but actually issues within #373 some testers already provided examples where at their full screen they couldn't see text.